### PR TITLE
fix: end date tomorrow

### DIFF
--- a/__tests__/helpers.spec.ts
+++ b/__tests__/helpers.spec.ts
@@ -36,10 +36,16 @@ END:VEVENT`);
 
 const today = new Date();
 
-let future = new Date();
+const tomorrow = new Date();
+tomorrow.setDate(today.getDate() + 1);
+
+const future = new Date();
 future.setDate(today.getDate() + 7);
 
-let past = new Date();
+const yesterday = new Date();
+yesterday.setDate(today.getDate() - 1);
+
+const past = new Date();
 past.setDate(today.getDate() - 7);
 
 beforeEach(() => {
@@ -55,10 +61,10 @@ describe("getEventsForEmployees", () => {
         {
           employee: "Yennefer OF VENGERBERG",
           start: today,
-          end: past,
+          end: tomorrow,
         },
-        { employee: "Geralt OF RIVIA", start: today, end: past },
-        { employee: "Ciri OF CINTRA", start: today, end: past },
+        { employee: "Geralt OF RIVIA", start: today, end: tomorrow },
+        { employee: "Ciri OF CINTRA", start: today, end: tomorrow },
       ]),
       ["Ciri OF CINTRA"],
     );
@@ -70,53 +76,46 @@ describe("getEventsForEmployees", () => {
   it("returns events that start today", () => {
     const result = getEventsForEmployees(
       getMockVEvents([
-        { employee: "Ciri OF CINTRA", start: past, end: past },
-        { employee: "Ciri OF CINTRA", start: today, end: past },
-      ]),
-      ["Ciri OF CINTRA"],
-    );
-
-    expect(result).toHaveLength(1);
-    expect(result[0].summary).toContain("Ciri OF CINTRA");
-  });
-
-  it("returns events that end today", () => {
-    const result = getEventsForEmployees(
-      getMockVEvents([
-        { employee: "Ciri OF CINTRA", start: past, end: today },
-        { employee: "Ciri OF CINTRA", start: past, end: past },
-      ]),
-      ["Ciri OF CINTRA"],
-    );
-
-    expect(result).toHaveLength(1);
-    expect(result[0].summary).toContain("Ciri OF CINTRA");
-  });
-
-  it("returns events that start and end today", () => {
-    const result = getEventsForEmployees(
-      getMockVEvents([
-        { employee: "Ciri OF CINTRA", start: past, end: past },
+        { employee: "Ciri OF CINTRA", start: past, end: yesterday },
+        { employee: "Ciri OF CINTRA", start: tomorrow, end: future },
         { employee: "Ciri OF CINTRA", start: today, end: today },
+        { employee: "Ciri OF CINTRA", start: today, end: tomorrow },
+        { employee: "Ciri OF CINTRA", start: today, end: future },
       ]),
       ["Ciri OF CINTRA"],
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].summary).toContain("Ciri OF CINTRA");
+    expect(result).toHaveLength(3);
+  });
+
+  // If it ends tomorrow, it means today is the last day of the event
+  it("returns events that end tomorrow", () => {
+    const result = getEventsForEmployees(
+      getMockVEvents([
+        { employee: "Ciri OF CINTRA", start: past, end: past },
+        { employee: "Ciri OF CINTRA", start: past, end: yesterday },
+        { employee: "Ciri OF CINTRA", start: past, end: today },
+        { employee: "Ciri OF CINTRA", start: past, end: tomorrow },
+        { employee: "Ciri OF CINTRA", start: yesterday, end: tomorrow },
+        { employee: "Ciri OF CINTRA", start: today, end: tomorrow },
+      ]),
+      ["Ciri OF CINTRA"],
+    );
+
+    expect(result).toHaveLength(3);
   });
 
   it("returns events that started in the past and end in the future", () => {
     const result = getEventsForEmployees(
       getMockVEvents([
         { employee: "Ciri OF CINTRA", start: past, end: past },
+        { employee: "Ciri OF CINTRA", start: yesterday, end: future },
         { employee: "Ciri OF CINTRA", start: past, end: future },
       ]),
       ["Ciri OF CINTRA"],
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].summary).toContain("Ciri OF CINTRA");
+    expect(result).toHaveLength(2);
   });
 });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,14 +18,17 @@ export const getEventsForEmployees = (
     (fullname) => `${PREFIX}${fullname}`,
   );
   const today = new Date().setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today + 24 * 60 * 60 * 1000).setHours(0, 0, 0, 0);
 
   return events.filter(({ summary, start, end }) => {
     // Only keep the events of the selected employees that start or end today
+    // Note: the end date is always +1 day
+    // Ex: if I'm off only today for a full day, then the end date will be tomorrow
     if (
       allowedSummaries.includes(summary) &&
       (start.getTime() === today ||
-        end.getTime() === today ||
-        (start.getTime() <= today && end.getTime() >= today))
+        end.getTime() === tomorrow ||
+        (start.getTime() <= today && end.getTime() >= tomorrow))
     ) {
       return true;
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,7 +21,7 @@ export const getEventsForEmployees = (
   const tomorrow = new Date(today + 24 * 60 * 60 * 1000).setHours(0, 0, 0, 0);
 
   return events.filter(({ summary, start, end }) => {
-    // Only keep the events of the selected employees that start or end today
+    // Only keep the events of the selected employees that start today or end tomorrow
     // Note: the end date is always +1 day
     // Ex: if I'm off only today for a full day, then the end date will be tomorrow
     if (


### PR DESCRIPTION
Turns out when you are off for one day, the start date is today but the end date is tomorrow in the generate ics file coming from payfit.

Updated the condition and tests to handle this.