### PR TITLE
fix: adjust all start & end times so they're all UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,21 @@ jobs:
       - name: Print Output
         id: output
         run: echo "${{ steps.test-action.outputs.names }}"
+
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/__tests__/helpers.spec.ts
+++ b/__tests__/helpers.spec.ts
@@ -5,6 +5,9 @@ import { getEmployeesFromEvents, getEventsForEmployees } from "../src/helpers";
 // Mock the GitHub Actions core library
 let infoMock: jest.SpiedFunction<typeof core.info>;
 
+jest.useFakeTimers();
+jest.setSystemTime(new Date('2024-04-29T00:00:00Z'));
+
 // Some helper to easily get parsed VEvent - this is what a parsed ICS file would return as well via node-ical
 const getMockVEvents = (
   eventsOptions: {

--- a/__tests__/helpers.spec.ts
+++ b/__tests__/helpers.spec.ts
@@ -1,6 +1,6 @@
 import { VEvent, sync as icalSync } from "node-ical";
 import * as core from "@actions/core";
-import { getEmployeesFromEvents, getEventsForEmployees } from "../src/helpers";
+import { adjustEventTimesToUTC, getEmployeesFromEvents, getEventsForEmployees } from "../src/helpers";
 
 // Mock the GitHub Actions core library
 let infoMock: jest.SpiedFunction<typeof core.info>;
@@ -34,7 +34,7 @@ END:VEVENT`);
   }
 
   // We never add VCalendar or VTimezone for our mocks so force the type to what we actually want it to be
-  return Object.values(icalSync.parseICS(body.join(""))) as VEvent[];
+  return adjustEventTimesToUTC(Object.values(icalSync.parseICS(body.join(""))) as VEvent[]);
 };
 
 const today = new Date();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { CalendarComponent, VEvent } from "node-ical";
+import { CalendarComponent, DateWithTimeZone, VEvent } from "node-ical";
 import * as core from "@actions/core";
 
 const PREFIX = "Absence - ";
@@ -17,8 +17,9 @@ export const getEventsForEmployees = (
   const allowedSummaries = employeeNames.map(
     (fullname) => `${PREFIX}${fullname}`,
   );
-  const today = new Date().setHours(0, 0, 0, 0);
-  const tomorrow = new Date(today + 24 * 60 * 60 * 1000).setHours(0, 0, 0, 0);
+  const now = new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate()));
+  const today = now.getTime();
+  const tomorrow = new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() + 1)).getTime();
 
   return events.filter(({ summary, start, end }) => {
     // Only keep the events of the selected employees that start today or end tomorrow
@@ -55,3 +56,16 @@ export const getEmployeesFromEvents = (employeeEvents: VEvent[]) => {
 
   return outOfOfficeEmployees;
 };
+
+/**
+ * Adjust the event times to UTC.
+ */
+export const adjustEventTimesToUTC = (events: VEvent[]) => {
+  return events.map(event => {
+    return {
+      ...event,
+      start: new Date(Date.UTC(event.start.getFullYear(), event.start.getMonth(), event.start.getDate())) as DateWithTimeZone,
+      end: new Date(Date.UTC(event.end.getFullYear(), event.end.getMonth(), event.end.getDate())) as DateWithTimeZone,
+    }
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { VEvent, async as icalAsync, sync as icalSync } from "node-ical";
 import * as core from "@actions/core";
-import { getEmployeesFromEvents, getEventsForEmployees } from "./helpers";
+import { adjustEventTimesToUTC, getEmployeesFromEvents, getEventsForEmployees } from "./helpers";
 
 export async function run(): Promise<void> {
   try {
@@ -31,7 +31,7 @@ export async function run(): Promise<void> {
 
     core.info(`Found a total of ${events.length} events in ical`);
 
-    const employeeEvents = getEventsForEmployees(events, names.split(","));
+    const employeeEvents = getEventsForEmployees(adjustEventTimesToUTC(events), names.split(","));
 
     const outOfOfficeEmployees = getEmployeesFromEvents(employeeEvents);
 


### PR DESCRIPTION
Fixing issue where node-ical parses events in the current timezone leading to some incorrect calculations.

Fixing it by forcing the parsed events to always be UTC by mapping the events right after they're being parsed.